### PR TITLE
Minor Mac OS fixes; basic PulseAudio driver on GNU/Linux

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,11 @@
 Package: audio
-Version: 0.1-7
+Version: 0.1-8
 Title: Audio Interface for R
-Author: Simon Urbanek <simon.urbanek@r-project.org>
-Maintainer: Simon Urbanek <simon.urbanek@r-project.org>
+Date: 2020-08-15
+Authors@R: c(
+    person("Simon", "Urbanek", rol=c("aut", "cph", "cre"), email="simon.urbanek@r-project.org"),
+    person("Bryan", "Lewis", rol="ctb", email="blewis@illposed.net"))
 Depends: R (>= 2.0.0)
-Description: Interfaces to audio devices (mainly sample-based) from R to allow recording and playback of audio. Built-in devices include Windows MM, Mac OS X AudioUnits and PortAudio (the last one is very experimental).
+Description: Interfaces to audio devices (mainly sample-based) from R to allow recording and playback of audio. Built-in devices include Windows MM, Mac OS X AudioUnits, GNU/Linux PulseAudio, and PortAudio (the last one is very experimental).
 License: MIT + file LICENSE
 URL: http://www.rforge.net/audio/

--- a/configure
+++ b/configure
@@ -2913,7 +2913,7 @@ $as_echo "${has_au}" >&6; }
 if ${PKGCONFIG} --version >/dev/null 2>&1; then
    if ${PKGCONFIG} portaudio-2.0; then
       CPPFLAGS="${CPPFLAGS} `${PKGCONFIG} --cflags portaudio-2.0`"
-      LIBS="${CPPFLAGS} `${PKGCONFIG} --libs portaudio-2.0`"
+      LIBS="${LIBS} `${PKGCONFIG} --libs portaudio-2.0`"
    fi
 fi
 
@@ -3488,6 +3488,26 @@ fi
 fi
 
 done
+
+
+# find PulseAudio via pkg-config
+: ${PKGCONFIG=pkg-config}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for PulseAudio" >&5
+$as_echo_n "checking for PulseAudio... " >&6; }
+if ${PKGCONFIG} --version >/dev/null 2>&1; then
+   if ${PKGCONFIG} libpulse-simple; then
+      CPPFLAGS="${CPPFLAGS} `${PKGCONFIG} --cflags portaudio-2.0`"
+      LIBS="${CPPFLAGS} ${LIBS} `${PKGCONFIG} --libs libpulse-simple libpulse`"
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+$as_echo "#define HAS_PULSE 1" >>confdefs.h
+
+   else
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+   fi
+fi
 
 
 # in any case configure produces config.h so we want to use it

--- a/configure.ac
+++ b/configure.ac
@@ -64,7 +64,7 @@ AC_MSG_RESULT([${has_au}])
 if ${PKGCONFIG} --version >/dev/null 2>&1; then
    if ${PKGCONFIG} portaudio-2.0; then
       CPPFLAGS="${CPPFLAGS} `${PKGCONFIG} --cflags portaudio-2.0`"
-      LIBS="${CPPFLAGS} `${PKGCONFIG} --libs portaudio-2.0`"
+      LIBS="${LIBS} `${PKGCONFIG} --libs portaudio-2.0`"
    fi
 fi
 
@@ -94,6 +94,21 @@ AC_DEFINE(HAS_PA, 1, [defined if PortAudio is available])
   ], [AC_MSG_RESULT([no])])
   ])
 ])
+
+# find PulseAudio via pkg-config
+: ${PKGCONFIG=pkg-config}
+AC_MSG_CHECKING([for PulseAudio])
+if ${PKGCONFIG} --version >/dev/null 2>&1; then
+   if ${PKGCONFIG} libpulse-simple; then
+      CPPFLAGS="${CPPFLAGS} `${PKGCONFIG} --cflags portaudio-2.0`"
+      LIBS="${CPPFLAGS} ${LIBS} `${PKGCONFIG} --libs libpulse-simple libpulse`"
+      AC_MSG_RESULT([yes])
+      AC_DEFINE(HAS_PULSE, 1, [defined if PulseAudio is available])
+   else
+      AC_MSG_RESULT([no])
+   fi
+fi
+
 
 # in any case configure produces config.h so we want to use it
 CPPFLAGS="-DHAS_CONFIG_H=1 ${CPPFLAGS}"

--- a/man/audio.drivers.Rd
+++ b/man/audio.drivers.Rd
@@ -43,7 +43,8 @@ load.audio.driver(path)
 \details{
   The audio package comes with several built-in audio drivers
   (currently "wmm": WindowsMultiMedia for MS Windows, "macosx":
-  AudioUnits for Mac OS X and "portaudio": PortAudio for unix), but it
+  AudioUnits for Mac OS X, "portaudio": PortAudio for unix,
+  and "pulseaudio": for GNU/Linux), but it
   also supports 3rd-party drivers to be loaded (e.g. from other
   packages).
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -9,6 +9,9 @@
 /* defined if PortAudio is available */
 #undef HAS_PA
 
+/* defined if PulseAudio is available */
+#undef HAS_PULSE
+
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #undef HAVE_DLFCN_H
 

--- a/src/driver.c
+++ b/src/driver.c
@@ -56,6 +56,9 @@ extern audio_driver_t wmmaudio_audio_driver;
 #if HAS_PA
 extern audio_driver_t portaudio_audio_driver;
 #endif
+#if HAS_PULSE
+extern audio_driver_t pulseaudio_audio_driver;
+#endif
 #if HAS_AU
 extern audio_driver_t audiounits_audio_driver;
 #endif
@@ -98,6 +101,9 @@ static void load_default_audio_driver(int silent)
 #endif
 #if HAS_PA
 	set_audio_driver(&portaudio_audio_driver);
+#endif
+#if HAS_PULSE
+  set_audio_driver(&pulseaudio_audio_driver);
 #endif
 	/* pick the first one - it will be NULL if there are no drivers */
 	current_driver = audio_drivers.driver;

--- a/src/file.c
+++ b/src/file.c
@@ -35,33 +35,13 @@
 
 #include <stdio.h>
 #include <string.h>
+#include "riff.h"
 
 #define USE_RINTERNALS  /* for efficiency */
 #define R_NO_REMAP      /* to not pollute the namespace */
 
 #include <R.h>
 #include <Rinternals.h>
-
-/* WAVE file is essentially a RIFF file, hence the structures */
-
-typedef struct riff_header {
-	char riff[4]; /* RIFF */
-	unsigned int len;
-	char type[4]; /* file type (WAVE) for wav */
-} riff_header_t;
-
-typedef struct riff_chunk {
-	char rci[4];
-	unsigned int len;
-} riff_chunk_t;
-
-typedef struct wav_fmt {
-	char rci[4]; /* RIFF chunk identifier, "fmt " here */
-	unsigned int len;
-	short ver, chs;
-	unsigned int rate, bps;
-	unsigned short byps, bips;
-} wav_fmt_t;
 
 SEXP load_wave_file(SEXP src)
 {

--- a/src/pulse.c
+++ b/src/pulse.c
@@ -61,7 +61,7 @@ static audio_instance_t *pulseaudio_create_player(SEXP source, float rate, int f
   unsigned int size = LENGTH(ap->source) * 2;
   R_PreserveObject(ap->source);
   ap->ss.format = PA_SAMPLE_S16LE;
-  ap->ss.rate = (uint32_t) rate;
+  ap->ss.rate = (uint32_t)rate;
   ap->done = 0;
   ap->length = LENGTH(source);
   ap->stereo = 0;
@@ -76,7 +76,7 @@ static audio_instance_t *pulseaudio_create_player(SEXP source, float rate, int f
   } else {
     ap->ss.channels = 1;
   }
-  return (audio_instance_t*) ap; /* pulse_instance_t is a superset of audio_instance_t */
+  return (audio_instance_t *)ap; /* pulse_instance_t is a superset of audio_instance_t */
 }
 
 static int pulseaudio_start(void *usr) {

--- a/src/pulse.c
+++ b/src/pulse.c
@@ -1,0 +1,233 @@
+/* Audio device for R using PulseAudio library
+   based on PortAudio library code: Copyright(c) 2008 Simon Urbanek
+
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the "Software"), to deal in the Software without
+   restriction, including without limitation the rights to use, copy,
+   modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   * The above copyright notice and this permission notice shall be
+     included in all copies or substantial portions of the Software.
+ 
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT 0T LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND ON
+   INFRINGEMENT. 
+   IN 0 EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+   ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+   CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+   WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ 
+   The text above constitutes the entire license; however, the
+   PortAudio community also makes the following non-binding requests:
+
+   * Any person wishing to distribute modifications to the Software is
+     requested to send the modifications to the original developer so
+     that they can be incorporated into the canonical version. It is
+     also requested that these non-binding requests be included along
+     with the license above.
+
+ */
+
+#include "driver.h"
+#include "riff.h"
+#if HAS_PULSE
+
+#include <pulse/simple.h>
+#include <pulse/error.h>
+#include <pulse/gccmacro.h>
+#define BUFSIZE 2048
+
+typedef struct pulse_instance {
+  /* the following entries must be present since pulse_instance_t inherits from audio_instance_t */
+  audio_driver_t *driver;  /* must point to the driver that created this */
+  int kind;                /* must be either AI_PLAYER or AI_RECORDER */
+  SEXP source;
+  /* custom entries */
+  pa_sample_spec ss;
+  pa_simple *s;
+  int stereo;
+  int done;
+  unsigned int length;
+} pulse_instance_t;
+  
+
+static audio_instance_t *pulseaudio_create_player(SEXP source, float rate, int flags) {
+  pulse_instance_t *ap = (pulse_instance_t*) calloc(sizeof(pulse_instance_t), 1);
+  ap->source = source;
+  unsigned int size = LENGTH(ap->source) * 2;
+  R_PreserveObject(ap->source);
+  ap->ss.format = PA_SAMPLE_S16LE;
+  ap->ss.rate = (uint32_t) rate;
+  ap->done = 0;
+  ap->length = LENGTH(source);
+  ap->stereo = 0;
+  { /* if the source is a matrix with 2 rows then we'll use stereo */
+    SEXP dim = Rf_getAttrib(source, R_DimSymbol);
+    if (TYPEOF(dim) == INTSXP && LENGTH(dim) > 0 && INTEGER(dim)[0] == 2)
+      ap->stereo = 1;
+  }
+  if (ap->stereo == 1) {
+    ap->length /= 2;
+    ap->ss.channels = 2;
+  } else {
+    ap->ss.channels = 1;
+  }
+  return (audio_instance_t*) ap; /* pulse_instance_t is a superset of audio_instance_t */
+}
+
+static int pulseaudio_start(void *usr) {
+  pulse_instance_t *ap = (pulse_instance_t*) usr;
+  char msg[1024];
+  int i, error;
+  size_t r;
+  unsigned int bits = 16, bps = 2, chs = 1, rate;
+  unsigned int size = LENGTH(ap->source);
+  ap->s = pa_simple_new(NULL, "R", PA_STREAM_PLAYBACK, NULL,
+                "R audio playback", &ap->ss, NULL, NULL, NULL);
+  if(!ap->s) Rf_error("cannot initialize PulseAudio system");
+  if(ap->stereo == 1) chs = 2;
+  rate = ap->ss.rate; /* already unsigned int, no conversion needed */
+  SEXP dim =  Rf_getAttrib(ap->source, Rf_install("bits"));
+  if (TYPEOF(dim) == INTSXP || TYPEOF(dim) == REALSXP) {
+    i = Rf_asInteger(dim);
+    if (i == 8) {
+      size /= 2;
+      bits = 8;
+      bps = 1;
+    } else if (i == 32) {
+      size *= 2;
+      bits = 32;
+      bps = 4;
+    }
+  }
+  bps *= chs;
+  riff_header_t rh = { "RIFF", size + 36, "WAVE" };
+  wav_fmt_t fmt = { "fmt ", 16, 1, chs, rate, rate * bps, bps, bits };
+  riff_chunk_t rc = { "data", size };
+  /* send header to Pulse Audio */
+  r = sizeof(riff_header_t);
+  if (pa_simple_write(ap->s, &rh, r, &error) < 0) {
+    Rf_error("PulseAudio write error");
+  }
+  r = sizeof(wav_fmt_t);
+  if (pa_simple_write(ap->s, &fmt, r, &error) < 0) {
+    Rf_error("PulseAudio write error");
+  }
+  r = sizeof(riff_chunk_t);
+  if (pa_simple_write(ap->s, &rc, r, &error) < 0) {
+    Rf_error("PulseAudio write error");
+  }
+  {
+    if (bits == 8) {
+      double *d = REAL(ap->source);
+      short int buf[BUFSIZE];
+      int i = 0, j = LENGTH(ap->source), k = 0;
+      while (i < j) {
+        R_CheckUserInterrupt();
+        buf[k++] = (signed char) (d[i++] * 127.0);
+        if (k == BUFSIZE) {
+          if (pa_simple_write(ap->s, buf, sizeof(*buf) * k, &error) < 0) {
+            Rf_error("PulseAudio write error");
+          }
+          k = 0;
+        }
+      }
+      if (pa_simple_write(ap->s, buf, sizeof(*buf) * k, &error) < 0) {
+        Rf_error("PulseAudio write error");
+      }
+    } else if (bits == 16) {
+      double *d = REAL(ap->source);
+      short int buf[BUFSIZE];
+      int i = 0, j = LENGTH(ap->source), k = 0;
+      while (i < j) {
+        R_CheckUserInterrupt();
+        buf[k++] = (short int) (d[i++] * 32767.0);
+        if (k == BUFSIZE) {
+          if (pa_simple_write(ap->s, buf, sizeof(*buf) * k, &error) < 0) {
+            Rf_error("PulseAudio write error");
+          }
+          k = 0;
+        }
+      }
+      if (pa_simple_write(ap->s, buf, sizeof(*buf) * k, &error) < 0) {
+        Rf_error("PulseAudio write error");
+      }
+    } else {
+      double *d = REAL(ap->source);
+      int buf[BUFSIZE];
+      int i = 0, j = LENGTH(ap->source), k = 0;
+      while (i < j) {
+        R_CheckUserInterrupt();
+        buf[k++] = (int) (d[i++] * 2147483647.0);
+        if (k == BUFSIZE) {
+          if (pa_simple_write(ap->s, buf, sizeof(*buf) * k, &error) < 0) {
+            Rf_error("PulseAudio write error");
+          }
+          k = 0;
+        }
+      }
+      if (pa_simple_write(ap->s, buf, sizeof(*buf) * k, &error) < 0) {
+        Rf_error("PulseAudio write error");
+      }
+    }
+  }
+  if (pa_simple_drain(ap->s, &error) < 0) Rf_error("PulseAudio write error");
+  return 1;
+}
+
+static int pulseaudio_pause(void *usr) {
+  R_ShowMessage("not supported yet");
+  return 1;
+}
+
+static int pulseaudio_resume(void *usr) {
+  R_ShowMessage("not supported yet");
+  return 1;
+}
+
+static int pulseaudio_rewind(void *usr) {
+  R_ShowMessage("not supported yet");
+  return 1;
+}
+
+static int pulseaudio_wait(void *usr, double timeout) {
+  R_ShowMessage("not supported yet");
+  return 1;
+}
+
+static int pulseaudio_close(void *usr) {
+  pulse_instance_t *p = (pulse_instance_t*) usr;
+  if(p->s) pa_simple_flush(p->s, NULL);
+  return 1;
+}
+
+static void pulseaudio_dispose(void *usr) {
+  pulse_instance_t *p = (pulse_instance_t*) usr;
+  if(p->s) pa_simple_free(p->s);
+  free(usr);
+}
+
+/* define the audio driver */
+audio_driver_t pulseaudio_audio_driver = {
+  sizeof(audio_driver_t),
+
+  "pulseaudio",
+  "PulseAudio driver",
+  "Copyright(c) 2020 Bryan Lewis",
+
+  pulseaudio_create_player,
+  0, /* recorder is currently unimplemented */
+  pulseaudio_start,
+  pulseaudio_pause,
+  pulseaudio_resume,
+  pulseaudio_rewind,
+  pulseaudio_wait,
+  pulseaudio_close,
+  pulseaudio_dispose
+};
+
+#endif

--- a/src/riff.h
+++ b/src/riff.h
@@ -1,0 +1,55 @@
+/* WAVE RIFF format headers for
+   audio R package
+   Copyright(c) 2008 Simon Urbanek
+
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the "Software"), to deal in the Software without
+   restriction, including without limitation the rights to use, copy,
+   modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   * The above copyright notice and this permission notice shall be
+     included in all copies or substantial portions of the Software.
+ 
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND ON
+   INFRINGEMENT. 
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+   ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+   CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+   WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ 
+   The text above constitutes the entire license; however, the
+   PortAudio community also makes the following non-binding requests:
+
+   * Any person wishing to distribute modifications to the Software is
+     requested to send the modifications to the original developer so
+     that they can be incorporated into the canonical version. It is
+     also requested that these non-binding requests be included along
+     with the license above.
+
+ */
+
+/* WAVE file is essentially a RIFF file, hence the structures */
+
+typedef struct riff_header {
+	char riff[4]; /* RIFF */
+	unsigned int len;
+	char type[4]; /* file type (WAVE) for wav */
+} riff_header_t;
+
+typedef struct riff_chunk {
+	char rci[4];
+	unsigned int len;
+} riff_chunk_t;
+
+typedef struct wav_fmt {
+	char rci[4]; /* RIFF chunk identifier, "fmt " here */
+	unsigned int len;
+	short ver, chs;
+	unsigned int rate, bps;
+	unsigned short byps, bips;
+} wav_fmt_t;


### PR DESCRIPTION
1. Fix a few warnings on Mac OS X >= 10.6 due to API deprecation changes
2. Add very basic PulseAudio driver for GNU/Linux

The PulseAudio driver provides as a basic alternative to the PortAudio driver on GNU/Linux systems (I've run into recent systems where PortAudio is not working and couldn't figure out how to fix that).

Consider this a draft implementation of a PulseAudio driver -- it's ony synchronous, but does at least respond to interrupts. Future versions can implement a full asynchronous record/play driver similar to the au one with more programming effort.